### PR TITLE
Cht 27 add signal r connection

### DIFF
--- a/docs/chat-realtime-spec.md
+++ b/docs/chat-realtime-spec.md
@@ -1,0 +1,173 @@
+## Chatty – Realtime & Presence Spec (Frontend + Backend TODO)
+
+This file summarizes what we discussed and what needs to be built, so you and your backend dev can implement it cleanly later.
+
+---
+
+### 1. Online status (presence)
+
+**Goal:**  
+Show whether a user is online both:
+- Inside the chat header
+- In the sidebar list (green dot, “online” label)
+
+**Rules:**
+- A user is **online** when they have an active SignalR connection.
+- A user is **offline** when all their SignalR connections have disconnected.
+
+**Backend responsibilities:**
+1. In `ChatHub.OnConnectedAsync`:
+   - Get `userId = Context.UserIdentifier`.
+   - Mark that user as `online` (DB or cache).
+   - Broadcast presence change:
+     ```csharp
+     await Clients.All.SendAsync("UserStatusChanged", new { userId, status = "online" });
+     ```
+
+2. In `ChatHub.OnDisconnectedAsync`:
+   - Mark that user as `offline` (only if they have no other active connections).
+   - Broadcast:
+     ```csharp
+     await Clients.All.SendAsync("UserStatusChanged", new { userId, status = "offline" });
+     ```
+
+3. Include `status` in:
+   - `GetCurrentUser` response
+   - `/chat/user-chats` response (`UserChat.status`)
+
+**Frontend responsibilities (later):**
+- Add a `usePresence` or extend `useSignalR` to listen to:
+  ```ts
+  connection.on("UserStatusChanged", ({ userId, status }) => { ... });
+  ```
+- In `ChatSidebar`, update `ChatUserDisplay.status` for matching chats.
+- In `ChatWindow`, use **other participant’s** status, not `isConnected`, for the “Online” text.
+
+---
+
+### 2. Realtime sidebar last message
+
+**Goal:**  
+Sidebar should always show the **latest message** and order chats by most recent activity without manual refresh.
+
+**Current frontend behavior (done):**
+- `ChatSidebar`:
+  - Fetches chats once via `getUserChats()`.
+  - Uses `useSignalR(null)` to listen to **all** `MessageReceived` events.
+  - When a new message arrives:
+    - Finds matching chat by `chatId`.
+    - Updates:
+      - `lastMessage` = `message.content`
+      - `lastTime` = `message.sentAt/createdAt`
+    - Moves that chat to the top of the list.
+
+**Backend requirement:**  
+No extra requirement if `MessageReceived` already includes:
+- `chatId`
+- `content`
+- `sentAt`/`timestamp`
+
+---
+
+### 3. Message delivery ticks (static design now, dynamic later)
+
+We want WhatsApp-style message states with icons:
+
+1. **Clock**  
+   - Meaning: Message is still **pending locally** (not accepted by server).
+2. **One gray tick**  
+   - Meaning: Message **saved on server** but receiver might not be connected yet.
+3. **Two gray ticks**  
+   - Meaning: Message **delivered** to receiver’s device.
+4. **Two blue ticks**  
+   - Meaning: Receiver has **seen** the message (chat opened / marked read).
+
+#### Static frontend API (design)
+
+```ts
+// src/types/chat/chat.models.ts
+export type MessageStatus = "pending" | "sent" | "delivered" | "seen";
+
+export interface ChatMessage {
+  ...
+  status?: MessageStatus;
+}
+```
+
+```tsx
+// src/components/common/ChatWindow.tsx (MessageStatus component)
+const MessageStatus = ({ status }: { status?: MessageStatus }) => {
+  if (status === "pending") return <ClockIcon className="w-4 h-4 text-gray-400" />;
+  if (status === "sent") return <OneTickIcon className="w-4 h-4 text-gray-400" />;
+  if (status === "delivered") return <TwoTicksIcon className="w-4 h-4 text-gray-400" />;
+  if (status === "seen") return <TwoTicksIcon className="w-4 h-4 text-blue-500" />;
+  return null;
+};
+```
+
+Right now we can keep it **static**:
+- Set `status: "sent"` when the server returns successfully.
+- Later, backend will send real statuses via SignalR.
+
+#### Backend responsibilities (to be done later)
+
+1. Extend `Message` model:
+   ```csharp
+   public enum MessageStatus { Pending, Sent, Delivered, Seen }
+
+   public class Message {
+     ...
+     public MessageStatus Status { get; set; }
+   }
+   ```
+
+2. When `ChatHub.SendMessage` (or API) saves the message:
+   - Set `Status = MessageStatus.Sent`.
+   - Broadcast `MessageReceived` with that status.
+
+3. When message is **delivered** to receiver:
+   - Decide the event logic (e.g. when receiver’s client confirms receipt).
+   - Update `Status` to `Delivered`.
+   - Broadcast:
+     ```csharp
+     await Clients.Group(chatId)
+       .SendAsync("MessageStatusChanged", new { messageId, status = "delivered" });
+     ```
+
+4. When message is **seen**:
+   - Add an endpoint or hub method like `MarkMessagesAsSeen(chatId)`.
+   - Update status to `Seen` for relevant messages.
+   - Broadcast `MessageStatusChanged` with status `"seen"`.
+
+#### Frontend after backend is ready
+
+- Listen for:
+  ```ts
+  connection.on("MessageStatusChanged", ({ messageId, status }) => {
+    setMessages(prev => prev.map(m =>
+      m.id === messageId ? { ...m, status } : m
+    ));
+  });
+  ```
+- `MessageStatus` component (above) will automatically render the right icon/color.
+
+---
+
+### 4. Summary of TODOs (backend first, then frontend)
+
+**Backend:**
+1. Implement presence in `ChatHub` (`OnConnectedAsync` / `OnDisconnectedAsync`) and broadcast `"UserStatusChanged"`.
+2. Persist and expose `status` for users (online/offline) in APIs.
+3. Extend `Message` with `Status` and implement transitions:
+   - `Pending` → `Sent` → `Delivered` → `Seen`.
+4. Broadcast:
+   - `"MessageReceived"` with full message payload (including `status`).
+   - `"MessageStatusChanged"` when only the status changes.
+
+**Frontend (after backend done):**
+1. Use `"UserStatusChanged"` to drive presence in chat header + sidebar.
+2. Use `Message.status` + `"MessageStatusChanged"` to drive the tick icons:
+   - clock / one tick / two gray ticks / two blue ticks.
+
+For now, the icons and status type can stay **static** in the frontend, and this file documents everything needed so you can coordinate with your backend dev and plug it in later.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fullcalendar/list": "^6.1.15",
         "@fullcalendar/react": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",
+        "@microsoft/signalr": "^10.0.0",
         "@react-jvectormap/core": "^1.0.4",
         "@react-jvectormap/world": "^1.1.2",
         "@reduxjs/toolkit": "^2.9.0",
@@ -2492,6 +2493,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@microsoft/signalr": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.9",
       "license": "MIT",
@@ -3654,6 +3668,18 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
       "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA=="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -5722,6 +5748,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -5770,6 +5814,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -7213,6 +7267,26 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -7674,13 +7748,30 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -8026,6 +8117,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -8159,6 +8256,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -8928,6 +9031,27 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "dev": true,
@@ -9107,6 +9231,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/unrs-resolver": {
@@ -9388,6 +9521,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
@@ -9395,6 +9538,22 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -9498,6 +9657,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fullcalendar/list": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
     "@fullcalendar/timegrid": "^6.1.15",
+    "@microsoft/signalr": "^10.0.0",
     "@react-jvectormap/core": "^1.0.4",
     "@react-jvectormap/world": "^1.1.2",
     "@reduxjs/toolkit": "^2.9.0",

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -10,10 +10,10 @@ export default function ChatPage() {
   return (
     <>
       {activeUserId ? (
-        <ChatWindow userId={activeUserId} />
+        <ChatWindow chatId={activeUserId} />
       ) : (
         <div className="text-center text-gray-500 mt-20">
-          👋 Select a user to start chatting
+          👋 Select a chat to start messaging
         </div>
       )}
     </>

--- a/src/components/common/ChatWindow.tsx
+++ b/src/components/common/ChatWindow.tsx
@@ -135,7 +135,7 @@ export default function ChatWindow({ chatId }: ChatWindowProps) {
     }
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSendMessage();
@@ -298,7 +298,7 @@ export default function ChatWindow({ chatId }: ChatWindowProps) {
             type="text"
             value={message}
             onChange={(e) => setMessage(e.target.value)}
-            onKeyPress={handleKeyPress}
+            onKeyDown={handleKeyDown}
             placeholder="Type a message..."
             disabled={sending || !isConnected}
             className="flex-1 rounded-full px-4 py-2 bg-white dark:bg-stone-700 focus:outline-none text-gray-800 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 disabled:opacity-50"

--- a/src/components/common/ChatWindow.tsx
+++ b/src/components/common/ChatWindow.tsx
@@ -1,203 +1,359 @@
 "use client";
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Send, Paperclip, Mic, Image, FileText, Camera, Check, CheckCheck, Phone, EllipsisVertical, Info, Trash2, XCircle, Search } from "lucide-react";
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";
+import { useSignalR } from "@/hooks/useSignalR";
+import { getMessages, sendMessage } from "@/lib/api/message";
+import { ChatMessage } from "@/types/chat/chat.models";
+import { useAppSelector } from "@/store/hooks";
+import { getErrorMessage } from "@/utils/error";
+import { showToast } from "@/utils/toast";
 
-const fakeUsers = {
-    u1: { name: "Alice Johnson" },
-    u2: { name: "Bob Smith" },
-    u3: { name: "Charlie Brown" },
-};
+interface ChatWindowProps {
+  chatId: string;
+}
 
-const fakeMessages = [
-    { id: 1, text: "Hello 👋", isOwn: false, status: "seen", timestamp: "10:30" },
-    { id: 2, text: "Hi Alice! How are you doing today?", isOwn: true, status: "seen", timestamp: "10:31" },
-    { id: 3, text: "I'm doing great, thanks for asking!", isOwn: false, status: "seen", timestamp: "10:32" },
-    { id: 4, text: "That's wonderful to hear! I was thinking we could catch up over coffee sometime this week.", isOwn: true, status: "delivered", timestamp: "10:33" },
-    { id: 5, text: "Sounds perfect! I'd love that ☕", isOwn: false, status: "seen", timestamp: "10:34" },
-];
+export default function ChatWindow({ chatId }: ChatWindowProps) {
+  const [message, setMessage] = useState("");
+  const [showAttachments, setShowAttachments] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [sending, setSending] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const currentUser = useAppSelector((state) => state.auth.user);
 
-export default function ChatWindow({ userId = "u1" }: { userId?: string }) {
-    const [message, setMessage] = useState("");
-    const [showAttachments, setShowAttachments] = useState(false);
-    const [messages, setMessages] = useState(fakeMessages);
-    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const user = fakeUsers[userId];
+  // Use SignalR hook for real-time messaging
+  const { messages, setMessages, sendMessage: sendSignalRMessage, isConnected, addMessage } = useSignalR(chatId);
 
-    const MessageStatus = ({ status }) => {
-        if (status === "sent") return <Check className="w-4 h-4 text-gray-400" />;
-        if (status === "delivered") return <CheckCheck className="w-4 h-4 text-gray-400" />;
-        if (status === "seen") return <CheckCheck className="w-4 h-4 text-green-500" />;
-        return null;
+  // Helper to ensure content is always a string
+  const ensureStringContent = (content: any): string => {
+    if (typeof content === 'string') {
+      return content;
+    }
+    if (content === null || content === undefined) {
+      return '';
+    }
+    if (typeof content === 'object') {
+      // If it's an object, try to extract a meaningful string
+      if (content.text) return String(content.text);
+      if (content.message) return String(content.message);
+      // Otherwise, stringify it
+      return JSON.stringify(content);
+    }
+    return String(content);
+  };
+
+  // Fetch existing messages when chatId changes
+  useEffect(() => {
+    const fetchMessages = async () => {
+      try {
+        const fetchedMessages = await getMessages(chatId);
+        // Transform messages to match our format
+        const transformedMessages: ChatMessage[] = fetchedMessages.map((msg: any) => {
+          // Extract nested properties and flatten
+          const transformed: ChatMessage = {
+            id: String(msg.id || ''),
+            content: ensureStringContent(msg.content),
+            senderId: String(msg.senderId || msg.sender?.id || ''),
+            chatId: String(msg.chatId || msg.chat?.id || chatId),
+            timestamp: msg.sentAt || msg.createdAt || msg.timestamp || new Date().toISOString(),
+            sentAt: msg.sentAt,
+            createdAt: msg.createdAt,
+            isRead: msg.isRead,
+            status: msg.status,
+            // Keep nested objects for future use
+            sender: msg.sender,
+            chat: msg.chat,
+          };
+          return transformed;
+        });
+        setMessages(transformedMessages);
+      } catch (err) {
+        console.error("Error fetching messages:", err);
+        showToast.error(getErrorMessage(err));
+      }
     };
 
-    const handleSendMessage = () => {
-        if (!message.trim()) return;
-        const newMessage = {
-            id: messages.length + 1,
-            text: message,
-            isOwn: true,
-            status: "sent",
-            timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-        };
-        setMessages([...messages, newMessage]);
-        setMessage("");
+    if (chatId) {
+      fetchMessages();
+    }
+  }, [chatId, setMessages]);
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const MessageStatus = ({ status }: { status?: string }) => {
+    if (status === "sent") return <Check className="w-4 h-4 text-gray-400" />;
+    if (status === "delivered") return <CheckCheck className="w-4 h-4 text-gray-400" />;
+    if (status === "seen") return <CheckCheck className="w-4 h-4 text-green-500" />;
+    return null;
+  };
+
+  const handleSendMessage = async () => {
+    if (!message.trim() || sending) return;
+
+    const messageContent = message.trim();
+    console.log('📤 Sending message:', {
+      chatId,
+      content: messageContent,
+      senderId: currentUser?.id,
+      timestamp: new Date().toISOString()
+    });
+    
+    setMessage("");
+    setSending(true);
+
+    // Optimistically add message to UI
+    const tempMessage: ChatMessage = {
+      id: `temp-${Date.now()}`,
+      content: messageContent,
+      senderId: currentUser?.id || "",
+      chatId: chatId,
+      sentAt: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
+      status: "sent",
     };
+    console.log('➕ Adding optimistic message to UI:', tempMessage);
+    addMessage(tempMessage);
 
-    const handleKeyPress = (e) => {
-        if (e.key === "Enter") handleSendMessage();
-    };
+    try {
+      console.log('🌐 Calling API to send message...');
+      // Send via API (which will also trigger SignalR)
+      // Include senderId from current user
+      const sentMessageResponse = await sendMessage(chatId, messageContent, currentUser?.id);
+      // Log only important fields (ignore null sender/chat objects)
+      console.log('✅ API response received:', {
+        id: sentMessageResponse.id,
+        content: sentMessageResponse.content,
+        chatId: sentMessageResponse.chatId,
+        senderId: sentMessageResponse.senderId,
+        sentAt: sentMessageResponse.sentAt,
+        hasSender: !!sentMessageResponse.sender,
+        hasChat: !!sentMessageResponse.chat
+      });
+      
+      // Transform the response to match our format
+      const sentMessage: ChatMessage = {
+        id: String(sentMessageResponse.id || ''),
+        content: ensureStringContent(sentMessageResponse.content),
+        senderId: String(sentMessageResponse.senderId || sentMessageResponse.sender?.id || currentUser?.id || ""),
+        chatId: String(sentMessageResponse.chatId || sentMessageResponse.chat?.id || chatId),
+        sentAt: sentMessageResponse.sentAt || sentMessageResponse.createdAt || sentMessageResponse.timestamp,
+        timestamp: sentMessageResponse.sentAt || sentMessageResponse.createdAt || sentMessageResponse.timestamp,
+        status: sentMessageResponse.status || "sent",
+        sender: sentMessageResponse.sender || undefined, // Convert null to undefined for cleaner logs
+        chat: sentMessageResponse.chat || undefined,
+      };
+      
+      console.log('🔄 Replacing temp message with real message:', {
+        id: sentMessage.id,
+        content: sentMessage.content,
+        chatId: sentMessage.chatId,
+        senderId: sentMessage.senderId
+      });
+      // Replace temp message with real one
+      setMessages((prev) => {
+        const filtered = prev.filter((m) => m.id !== tempMessage.id);
+        console.log(`📊 Messages after replacement: ${filtered.length} existing + 1 new = ${filtered.length + 1} total`);
+        return [...filtered, sentMessage];
+      });
+      
+      console.log('✅ Message sent successfully via API. Waiting for SignalR broadcast from backend...');
+      console.log('💡 Note: The backend should broadcast this message via SignalR to all clients in the chat group.');
+    } catch (err) {
+      console.error("❌ Error sending message:", err);
+      showToast.error(getErrorMessage(err));
+      // Remove failed message
+      setMessages((prev) => prev.filter((m) => m.id !== tempMessage.id));
+    } finally {
+      setSending(false);
+    }
+  };
 
-    const attachmentOptions = [
-        { icon: Camera, label: "Camera", color: "text-green-600" },
-        { icon: Image, label: "Photo & Video", color: "text-blue-600" },
-        { icon: FileText, label: "Document", color: "text-purple-600" },
-    ];
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  };
 
-    return (
-        <div className="flex flex-col h-[80vh] rounded-lg">
-            {/* Chat header */}
+  const formatTime = (timestamp?: string): string => {
+    if (!timestamp) return "";
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    } catch {
+      return timestamp;
+    }
+  };
+
+  const attachmentOptions = [
+    { icon: Camera, label: "Camera", color: "text-green-600" },
+    { icon: Image, label: "Photo & Video", color: "text-blue-600" },
+    { icon: FileText, label: "Document", color: "text-purple-600" },
+  ];
+
+  // Get display name for the chat (this would ideally come from the chat data)
+  const chatDisplayName = "Chat"; // TODO: Get from chat context or props
+
+  return (
+    <div className="flex flex-col h-[80vh] rounded-lg">
+      {/* Chat header */}
+      <div className="relative">
+        <div className="p-3 border-b dark:border-stone-700 flex justify-between items-center bg-gray-100 dark:bg-stone-800 rounded-t-lg">
+          {/* Left side (user info) */}
+          <div className="flex items-center">
+            <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold mr-3">
+              {chatDisplayName?.charAt(0) || "C"}
+            </div>
+            <div>
+              <span className="font-semibold text-gray-800 dark:text-gray-100 block">
+                {chatDisplayName}
+              </span>
+              <span className={`text-sm ${isConnected ? "text-green-500" : "text-gray-400"}`}>
+                {isConnected ? "Online" : "Connecting..."}
+              </span>
+            </div>
+          </div>
+
+          {/* Right side (actions) */}
+          <div className="flex items-center space-x-4">
+            <div className="bg-transparent hover:bg-[#1a7b9b] border border-gray-300 text-stone-700 hover:text-white hover:border-none dark:text-white dark:border-stone-700 cursor-pointer rounded-full p-3 h-11 w-11 flex items-center justify-center shadow-md transition-transform duration-200 hover:scale-110 hover:shadow-lg">
+              <Phone size={20} />
+            </div>
+
+            {/* Ellipsis with dropdown */}
             <div className="relative">
-                <div className="p-3 border-b dark:border-stone-700 flex justify-between items-center bg-gray-100 dark:bg-stone-800 rounded-t-lg">
-                    {/* Left side (user info) */}
-                    <div className="flex items-center">
-                        <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold mr-3">
-                            {user?.name?.charAt(0) || "U"}
-                        </div>
-                        <div>
-                            <span className="font-semibold text-gray-800 dark:text-gray-100 block">
-                                {user?.name || "Unknown User"}
-                            </span>
-                            <span className="text-sm text-green-500">Typing..</span>
-                        </div>
-                    </div>
+              <EllipsisVertical
+                size={20}
+                className="cursor-pointer dropdown-toggle bg-transparent hover:bg-gray-100 dark:hover:bg-stone-700 text-stone-700 hover:text-white hover:border-none dark:text-white rounded-full p-2 h-10 w-10 flex items-center justify-center transition-transform duration-200"
+                onClick={() => setIsDropdownOpen((prev) => !prev)}
+              />
 
-                    {/* Right side (actions) */}
-                    <div className="flex items-center space-x-4">
-                        <div className="bg-transparent hover:bg-[#1a7b9b] border border-gray-300 text-stone-700 hover:text-white hover:border-none dark:text-white dark:border-stone-700 cursor-pointer rounded-full p-3 h-11 w-11 flex items-center justify-center shadow-md transition-transform duration-200 hover:scale-110 hover:shadow-lg">
-                            <Phone size={20} />
-                        </div>
-
-                        {/* Ellipsis with dropdown */}
-                        <div className="relative">
-                            <EllipsisVertical
-                                size={20}
-                                className="cursor-pointer dropdown-toggle bg-transparent hover:bg-gray-100 dark:hover:bg-stone-700 text-stone-700 hover:text-white hover:border-none dark:text-white rounded-full p-2 h-10 w-10 flex items-center justify-center transition-transform duration-200"
-                                onClick={() => setIsDropdownOpen((prev) => !prev)}
-                            />
-
-                            <Dropdown isOpen={isDropdownOpen} onClose={() => setIsDropdownOpen(false)}>
-                                <div className="flex flex-col gap-2 w-[180px] rounded-lg border border-gray-200 bg-white shadow-theme-lg dark:border-stone-800 dark:bg-stone-950">
-                                    <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 rounded-t-lg group text-theme-sm hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300">
-                                        <Info className="w-4 h-4 mr-2 text-blue-500" />
-                                        Contact Info
-                                    </DropdownItem>
-                                    <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 group text-theme-sm hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300 border-b border-gray-200 dark:border-gray-800">
-                                        <Search className="w-4 h-4 mr-2 text-green-500" />
-                                        Search Messages
-                                    </DropdownItem>
-                                    <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 group text-theme-sm hover:text-gray-700 dark:text-gray-400 hover:bg-red-500/15 dark:hover:text-gray-300">
-                                        <XCircle className="w-4 h-4 mr-2 text-yellow-500" />
-                                        Clear Chat
-                                    </DropdownItem>
-                                    <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 rounded-b-lg group text-theme-sm hover:bg-red-500/15 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
-                                        <Trash2 className="w-4 h-4 mr-2 text-red-500" />
-                                        Delete Chat
-                                    </DropdownItem>
-                                </div>
-                            </Dropdown>
-                        </div>
-                    </div>
+              <Dropdown isOpen={isDropdownOpen} onClose={() => setIsDropdownOpen(false)}>
+                <div className="flex flex-col gap-2 w-[180px] rounded-lg border border-gray-200 bg-white shadow-theme-lg dark:border-stone-800 dark:bg-stone-950">
+                  <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 rounded-t-lg group text-theme-sm hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300">
+                    <Info className="w-4 h-4 mr-2 text-blue-500" />
+                    Contact Info
+                  </DropdownItem>
+                  <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 group text-theme-sm hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300 border-b border-gray-200 dark:border-gray-800">
+                    <Search className="w-4 h-4 mr-2 text-green-500" />
+                    Search Messages
+                  </DropdownItem>
+                  <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 group text-theme-sm hover:text-gray-700 dark:text-gray-400 hover:bg-red-500/15 dark:hover:text-gray-300">
+                    <XCircle className="w-4 h-4 mr-2 text-yellow-500" />
+                    Clear Chat
+                  </DropdownItem>
+                  <DropdownItem className="flex items-center justify-arround px-4 py-2 font-medium text-gray-700 rounded-b-lg group text-theme-sm hover:bg-red-500/15 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
+                    <Trash2 className="w-4 h-4 mr-2 text-red-500" />
+                    Delete Chat
+                  </DropdownItem>
                 </div>
+              </Dropdown>
             </div>
-
-            {/* Messages area */}
-            <div className="flex-1 overflow-y-auto p-4 space-y-3 bg-gray-50 dark:bg-stone-900 rounded-b-lg chat-scrollbar">
-                {messages.map((msg) => (
-                    <div key={msg.id} className={`flex ${msg.isOwn ? "justify-end" : "justify-start"}`}>
-                        <div className={`flex items-end space-x-2 max-w-[70%] ${msg.isOwn ? "flex-row-reverse space-x-reverse" : "flex-row"}`}>
-                            {!msg.isOwn && (
-                                <div className="w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center text-white text-xs font-semibold mb-1">
-                                    {user?.name?.charAt(0) || "U"}
-                                </div>
-                            )}
-
-                            <div className="relative group">
-                                <div
-                                    className={`px-2 py-1 rounded-2xl border-2 ${msg.isOwn
-                                        ? "bg-[#1a7b9b]/80 text-white border-blue-400 rounded-br-md"
-                                        : "bg-white dark:bg-stone-800 text-gray-800 dark:text-gray-100 border-gray-200 dark:border-stone-600 rounded-bl-md"
-                                        }`}
-                                >
-                                    <p className="text-sm leading-relaxed">{msg.text}</p>
-                                    <div className="flex items-center justify-end mt-1 space-x-1">
-                                        <span className={`text-[11px] ${msg.isOwn ? "text-blue-100" : "text-gray-500 dark:text-gray-400"}`}>
-                                            {msg.timestamp}
-                                        </span>
-                                        {msg.isOwn && <MessageStatus status={msg.status} />}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                ))}
-            </div>
-
-            {/* Input + Attachments */}
-            <div className="sticky bottom-0 mt-3 px-3 py-2 bg-gray-100 dark:bg-stone-800 rounded-full">
-                {/* Floating attachment menu */}
-                {showAttachments && (
-                    <div className="absolute bottom-14 left-3 z-20 bg-white dark:bg-stone-800 rounded-xl shadow-lg border dark:border-stone-600 w-fit">
-                        <div className="flex flex-col p-2">
-                            {attachmentOptions.map((option, index) => (
-                                <button
-                                    key={index}
-                                    className="flex items-center gap-3 px-4 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-stone-700 transition"
-                                    onClick={() => setShowAttachments(false)}
-                                >
-                                    <div className={`w-8 h-8 flex items-center justify-center rounded-full ${option.color} bg-opacity-10`}>
-                                        <option.icon className={`w-5 h-5 ${option.color}`} />
-                                    </div>
-                                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{option.label}</span>
-                                </button>
-                            ))}
-                        </div>
-                    </div>
-                )}
-
-                {/* Chat input row */}
-                <div className="flex items-center gap-2 relative">
-                    <button
-                        onClick={() => setShowAttachments(!showAttachments)}
-                        className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-stone-700 rounded-full transition-colors"
-                    >
-                        <Paperclip className="w-5 h-5" />
-                    </button>
-
-                    <input
-                        type="text"
-                        value={message}
-                        onChange={(e) => setMessage(e.target.value)}
-                        onKeyPress={handleKeyPress}
-                        placeholder="Type a message..."
-                        className="flex-1 rounded-full px-4 py-2 bg-white dark:bg-stone-700 focus:outline-none text-gray-800 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
-                    />
-
-                    <button className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-stone-700 rounded-full transition-colors">
-                        <Mic className="w-5 h-5" />
-                    </button>
-
-                    <button
-                        onClick={handleSendMessage}
-                        disabled={!message.trim()}
-                        className="bg-[#1a7b9b] hover:bg-[#1a7b9b]/80 text-white p-2 rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                        <Send className="w-4 h-4" />
-                    </button>
-                </div>
-            </div>
-
+          </div>
         </div>
-    );
+      </div>
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3 bg-gray-50 dark:bg-stone-900 rounded-b-lg chat-scrollbar">
+        {messages.length === 0 ? (
+          <div className="text-center text-gray-500 dark:text-gray-400 py-8">
+            No messages yet. Start the conversation!
+          </div>
+        ) : (
+          messages.map((msg) => {
+            const isOwn = msg.senderId === currentUser?.id;
+            return (
+              <div key={msg.id} className={`flex ${isOwn ? "justify-end" : "justify-start"}`}>
+                <div className={`flex items-end space-x-2 max-w-[70%] ${isOwn ? "flex-row-reverse space-x-reverse" : "flex-row"}`}>
+                  {!isOwn && (
+                    <div className="w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center text-white text-xs font-semibold mb-1">
+                      {chatDisplayName?.charAt(0) || "U"}
+                    </div>
+                  )}
+
+                  <div className="relative group">
+                    <div
+                      className={`px-2 py-1 rounded-2xl border-2 ${
+                        isOwn
+                          ? "bg-[#1a7b9b]/80 text-white border-blue-400 rounded-br-md"
+                          : "bg-white dark:bg-stone-800 text-gray-800 dark:text-gray-100 border-gray-200 dark:border-stone-600 rounded-bl-md"
+                      }`}
+                    >
+                      <p className="text-sm leading-relaxed">{ensureStringContent(msg.content)}</p>
+                      <div className="flex items-center justify-end mt-1 space-x-1">
+                        <span className={`text-[11px] ${isOwn ? "text-blue-100" : "text-gray-500 dark:text-gray-400"}`}>
+                          {formatTime(msg.sentAt || msg.timestamp || msg.createdAt)}
+                        </span>
+                        {isOwn && <MessageStatus status={msg.status} />}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input + Attachments */}
+      <div className="sticky bottom-0 mt-3 px-3 py-2 bg-gray-100 dark:bg-stone-800 rounded-full">
+        {/* Floating attachment menu */}
+        {showAttachments && (
+          <div className="absolute bottom-14 left-3 z-20 bg-white dark:bg-stone-800 rounded-xl shadow-lg border dark:border-stone-600 w-fit">
+            <div className="flex flex-col p-2">
+              {attachmentOptions.map((option, index) => (
+                <button
+                  key={index}
+                  className="flex items-center gap-3 px-4 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-stone-700 transition"
+                  onClick={() => setShowAttachments(false)}
+                >
+                  <div className={`w-8 h-8 flex items-center justify-center rounded-full ${option.color} bg-opacity-10`}>
+                    <option.icon className={`w-5 h-5 ${option.color}`} />
+                  </div>
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{option.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Chat input row */}
+        <div className="flex items-center gap-2 relative">
+          <button
+            onClick={() => setShowAttachments(!showAttachments)}
+            className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-stone-700 rounded-full transition-colors"
+          >
+            <Paperclip className="w-5 h-5" />
+          </button>
+
+          <input
+            type="text"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder="Type a message..."
+            disabled={sending || !isConnected}
+            className="flex-1 rounded-full px-4 py-2 bg-white dark:bg-stone-700 focus:outline-none text-gray-800 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 disabled:opacity-50"
+          />
+
+          <button className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-stone-700 rounded-full transition-colors">
+            <Mic className="w-5 h-5" />
+          </button>
+
+          <button
+            onClick={handleSendMessage}
+            disabled={!message.trim() || sending || !isConnected}
+            className="bg-[#1a7b9b] hover:bg-[#1a7b9b]/80 text-white p-2 rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Send className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/common/ChatWindow.tsx
+++ b/src/components/common/ChatWindow.tsx
@@ -4,7 +4,7 @@ import { Send, Paperclip, Mic, Image, FileText, Camera, Check, CheckCheck, Phone
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";
 import { useSignalR } from "@/hooks/useSignalR";
-import { getMessages, sendMessage } from "@/lib/api/message";
+import { getMessages } from "@/lib/api/message";
 import { ChatMessage } from "@/types/chat/chat.models";
 import { useAppSelector } from "@/store/hooks";
 import { getErrorMessage } from "@/utils/error";
@@ -119,51 +119,14 @@ export default function ChatWindow({ chatId }: ChatWindowProps) {
     addMessage(tempMessage);
 
     try {
-      console.log('🌐 Calling API to send message...');
-      // Send via API (which will also trigger SignalR)
-      // Include senderId from current user
-      const sentMessageResponse = await sendMessage(chatId, messageContent, currentUser?.id);
-      // Log only important fields (ignore null sender/chat objects)
-      console.log('✅ API response received:', {
-        id: sentMessageResponse.id,
-        content: sentMessageResponse.content,
-        chatId: sentMessageResponse.chatId,
-        senderId: sentMessageResponse.senderId,
-        sentAt: sentMessageResponse.sentAt,
-        hasSender: !!sentMessageResponse.sender,
-        hasChat: !!sentMessageResponse.chat
-      });
-      
-      // Transform the response to match our format
-      const sentMessage: ChatMessage = {
-        id: String(sentMessageResponse.id || ''),
-        content: ensureStringContent(sentMessageResponse.content),
-        senderId: String(sentMessageResponse.senderId || sentMessageResponse.sender?.id || currentUser?.id || ""),
-        chatId: String(sentMessageResponse.chatId || sentMessageResponse.chat?.id || chatId),
-        sentAt: sentMessageResponse.sentAt || sentMessageResponse.createdAt || sentMessageResponse.timestamp,
-        timestamp: sentMessageResponse.sentAt || sentMessageResponse.createdAt || sentMessageResponse.timestamp,
-        status: sentMessageResponse.status || "sent",
-        sender: sentMessageResponse.sender || undefined, // Convert null to undefined for cleaner logs
-        chat: sentMessageResponse.chat || undefined,
-      };
-      
-      console.log('🔄 Replacing temp message with real message:', {
-        id: sentMessage.id,
-        content: sentMessage.content,
-        chatId: sentMessage.chatId,
-        senderId: sentMessage.senderId
-      });
-      // Replace temp message with real one
-      setMessages((prev) => {
-        const filtered = prev.filter((m) => m.id !== tempMessage.id);
-        console.log(`📊 Messages after replacement: ${filtered.length} existing + 1 new = ${filtered.length + 1} total`);
-        return [...filtered, sentMessage];
-      });
-      
-      console.log('✅ Message sent successfully via API. Waiting for SignalR broadcast from backend...');
-      console.log('💡 Note: The backend should broadcast this message via SignalR to all clients in the chat group.');
+      console.log('📡 Calling SignalR hub SendMessage...');
+      // Send via SignalR hub (which will save + broadcast to all clients)
+      await sendSignalRMessage(messageContent, currentUser?.id);
+      console.log(
+        '✅ Message sent successfully via SignalR hub; waiting for broadcast to update UI.'
+      );
     } catch (err) {
-      console.error("❌ Error sending message:", err);
+      console.error('❌ Error sending message via SignalR hub:', err);
       showToast.error(getErrorMessage(err));
       // Remove failed message
       setMessages((prev) => prev.filter((m) => m.id !== tempMessage.id));

--- a/src/components/providers/RouteGuard.tsx
+++ b/src/components/providers/RouteGuard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useAppSelector } from "@/store/hooks";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+
+interface RouteGuardProps {
+  children: ReactNode;
+}
+
+/**
+ * Global route guard.
+ * - If user has no token, redirects to /auth/signin.
+ * - Auth routes (/auth/...) remain publicly accessible.
+ */
+export default function RouteGuard({ children }: RouteGuardProps) {
+  const { token, initialized } = useAppSelector((state) => state.auth);
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isAuthRoute = pathname?.startsWith("/auth");
+
+  useEffect(() => {
+    if (!mounted || !initialized) return;
+
+    // If not on an auth route and no token, redirect to signin
+    if (!isAuthRoute && !token) {
+      router.replace("/auth/signin");
+    }
+  }, [mounted, initialized, isAuthRoute, token, router]);
+
+  // While initializing or before mount, show a loader
+  if (!mounted || !initialized) {
+    return <LoadingSpinner size="xl" fullScreen text="Loading..." />;
+  }
+
+  // While redirecting away from protected routes, render nothing
+  if (!isAuthRoute && !token) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+

--- a/src/components/providers/providers.tsx
+++ b/src/components/providers/providers.tsx
@@ -6,18 +6,22 @@ import { Provider } from 'react-redux';
 import { store } from '@/store';
 import AuthProvider from './authProvider';
 import ToastProvider from './toastProvider';
+import RouteGuard from './RouteGuard';
 
 export function Providers({ children }: { children: ReactNode }) {
     return (
         <Provider store={store}>
             <AuthProvider>
-                <ThemeProvider>
-                    <SidebarProvider>
-                        {children}
-                        <ToastProvider />
-                    </SidebarProvider>
-                </ThemeProvider>
+                <RouteGuard>
+                    <ThemeProvider>
+                        <SidebarProvider>
+                            {children}
+                            <ToastProvider />
+                        </SidebarProvider>
+                    </ThemeProvider>
+                </RouteGuard>
             </AuthProvider>
         </Provider>
     );
 }
+

--- a/src/components/ui/sidebars/ChatSidebar.tsx
+++ b/src/components/ui/sidebars/ChatSidebar.tsx
@@ -50,6 +50,25 @@ const ChatSidebar = () => {
     }
   };
 
+  // Helper to ensure lastMessage is always a string
+  const ensureStringMessage = (message: any): string => {
+    if (typeof message === 'string') {
+      return message;
+    }
+    if (message === null || message === undefined) {
+      return '';
+    }
+    if (typeof message === 'object') {
+      // If it's a message object, extract the content
+      if (message.content) return String(message.content);
+      if (message.text) return String(message.text);
+      if (message.message) return String(message.message);
+      // Otherwise, stringify it
+      return JSON.stringify(message);
+    }
+    return String(message);
+  };
+
   // Fetch user chats from API
   useEffect(() => {
     const fetchChats = async () => {
@@ -93,7 +112,7 @@ const ChatSidebar = () => {
             name: name,
             avatar: avatar,
             status: chat.status || "offline",
-            lastMessage: chat.lastMessage || "",
+            lastMessage: ensureStringMessage(chat.lastMessage),
             lastTime: chat.lastMessageAt && chat.lastMessageAt !== "0001-01-01T00:00:00Z" 
               ? formatTime(chat.lastMessageAt) 
               : formatTime(chat.createdAt),

--- a/src/hooks/useSignalR.ts
+++ b/src/hooks/useSignalR.ts
@@ -19,6 +19,14 @@ export const useSignalR = (chatId: string | null) => {
     let isMounted = true;
     let currentConnection: HubConnection | null = null;
 
+    // Handlers kept in effect scope so we can .off(event, handler) in cleanup
+    let handleMessageReceived:
+      | ((message: any) => void)
+      | null = null;
+    let handleReconnecting: (() => void) | null = null;
+    let handleReconnected: (() => void) | null = null;
+    let handleClose: ((error?: Error) => void) | null = null;
+
     const initConnection = async () => {
       try {
         const conn = await startSignalRConnection();
@@ -44,17 +52,8 @@ export const useSignalR = (chatId: string | null) => {
           // Log all SignalR events for debugging
           console.log('🔍 Setting up SignalR event listeners...');
           
-          // Listen for ANY method call from SignalR (for debugging)
-          const originalInvoke = conn.invoke.bind(conn);
-          conn.invoke = function(method: string, ...args: any[]) {
-            console.log('📡 SignalR Invoke:', method, args);
-            return originalInvoke(method, ...args);
-          };
-          
-          // Set up message handler - use ref to get current chatId
-          // Backend broadcasts with ChatHubMethods.MessageReceived = "MessageReceived"
-          // so we must listen to that exact event name here.
-          conn.on('MessageReceived', (message: any) => {
+          // --- Handlers registered via .on(...) so we can .off(...) in cleanup ---
+          handleMessageReceived = (message: any) => {
             const currentChatId = chatIdRef.current;
             console.log('📨 Received message via SignalR:', {
               message,
@@ -118,38 +117,38 @@ export const useSignalR = (chatId: string | null) => {
                 currentChatId
               });
             }
-          });
-          
-          console.log('👂 SignalR message handler registered. Listening for "ReceiveMessage" events.');
-          
-          // Add a test listener to catch ANY SignalR messages (for debugging)
-          conn.onclose((error) => {
-            if (error) {
-              console.log('🔴 SignalR connection closed with error:', error);
-            }
-          });
-          
-          // Log when ANY method is called on the connection
-          console.log('🔍 Monitoring all SignalR events. If you see messages from backend, they will appear above.');
+          };
 
-          // Handle connection state changes
-          conn.onreconnecting(() => {
+          handleReconnecting = () => {
             console.log('🔄 SignalR reconnecting...');
             if (isMounted) setIsConnected(false);
-          });
+          };
 
-          conn.onreconnected(() => {
+          handleReconnected = () => {
             console.log('✅ SignalR reconnected');
             if (isMounted) setIsConnected(true);
-          });
+          };
 
-          conn.onclose(() => {
-            console.log('❌ SignalR connection closed');
+          handleClose = (error?: Error) => {
+            if (error) {
+              console.log('🔴 SignalR connection closed with error:', error);
+            } else {
+              console.log('❌ SignalR connection closed');
+            }
             if (isMounted) {
               setIsConnected(false);
               setConnection(null);
             }
-          });
+          };
+
+          // Register handlers with .on(...)
+          conn.on('MessageReceived', handleMessageReceived);
+          conn.on('reconnecting', handleReconnecting);
+          conn.on('reconnected', handleReconnected);
+          conn.on('close', handleClose);
+          
+          console.log('👂 SignalR message handler registered. Listening for "MessageReceived" events.');
+          console.log('🔍 Monitoring all SignalR events. If you see messages from backend, they will appear above.');
         }
       } catch (err) {
         console.error('Failed to initialize SignalR:', err);
@@ -167,10 +166,19 @@ export const useSignalR = (chatId: string | null) => {
       isMounted = false;
       if (currentConnection) {
         // Remove handlers before stopping
-        currentConnection.off('MessageReceived');
-        currentConnection.off('reconnecting');
-        currentConnection.off('reconnected');
-        currentConnection.off('close');
+        if (handleMessageReceived) {
+          currentConnection.off('MessageReceived', handleMessageReceived);
+        }
+        if (handleReconnecting) {
+          currentConnection.off('reconnecting', handleReconnecting);
+        }
+        if (handleReconnected) {
+          currentConnection.off('reconnected', handleReconnected);
+        }
+        if (handleClose) {
+          currentConnection.off('close', handleClose);
+        }
+
         stopSignalRConnection();
       }
     };

--- a/src/hooks/useSignalR.ts
+++ b/src/hooks/useSignalR.ts
@@ -52,7 +52,9 @@ export const useSignalR = (chatId: string | null) => {
           };
           
           // Set up message handler - use ref to get current chatId
-          conn.on('ReceiveMessage', (message: any) => {
+          // Backend broadcasts with ChatHubMethods.MessageReceived = "MessageReceived"
+          // so we must listen to that exact event name here.
+          conn.on('MessageReceived', (message: any) => {
             const currentChatId = chatIdRef.current;
             console.log('📨 Received message via SignalR:', {
               message,
@@ -84,13 +86,30 @@ export const useSignalR = (chatId: string | null) => {
               
               console.log('✅ Adding message to state:', transformedMessage);
               setMessages((prev) => {
-                // Avoid duplicates
+                // 1) If we already have this final message id, ignore
                 if (prev.some((m) => m.id === transformedMessage.id)) {
-                  console.log('⚠️ Duplicate message ignored:', transformedMessage.id);
+                  console.log('⚠️ Duplicate message ignored (same id):', transformedMessage.id);
                   return prev;
                 }
-                console.log(`📝 Message added. Total messages: ${prev.length + 1}`);
-                return [...prev, transformedMessage];
+
+                // 2) Remove any optimistic temp messages for same chat/sender/content
+                const filtered = prev.filter((m) => {
+                  const isTemp = typeof m.id === 'string' && m.id.startsWith('temp-');
+                  const sameChat = m.chatId === transformedMessage.chatId;
+                  const sameSender = m.senderId === transformedMessage.senderId;
+                  const sameContent =
+                    ensureStringContent(m.content) === ensureStringContent(transformedMessage.content);
+
+                  if (isTemp && sameChat && sameSender && sameContent) {
+                    console.log('🧹 Removing matching temp message:', m);
+                    return false;
+                  }
+
+                  return true;
+                });
+
+                console.log(`📝 Message added. Total messages: ${filtered.length + 1}`);
+                return [...filtered, transformedMessage];
               });
             } else {
               console.log('⚠️ Message filtered out:', {
@@ -148,7 +167,7 @@ export const useSignalR = (chatId: string | null) => {
       isMounted = false;
       if (currentConnection) {
         // Remove handlers before stopping
-        currentConnection.off('ReceiveMessage');
+        currentConnection.off('MessageReceived');
         currentConnection.off('reconnecting');
         currentConnection.off('reconnected');
         currentConnection.off('close');
@@ -193,18 +212,37 @@ export const useSignalR = (chatId: string | null) => {
     };
   }, [connection, chatId, isConnected]);
 
-  const sendMessage = useCallback(async (content: string) => {
-    if (!connection || !chatId || !isConnected) {
-      throw new Error('Not connected to chat');
-    }
+  // Send a message via SignalR Hub (ChatHub.SendMessage)
+  // Backend signature: Task<Message> SendMessage(string chatId, Message message)
+  const sendMessage = useCallback(
+    async (content: string, senderId?: string) => {
+      if (!connection || !chatId || !isConnected) {
+        throw new Error('Not connected to chat');
+      }
 
-    try {
-      await connection.invoke('SendMessage', chatId, content);
-    } catch (err) {
-      console.error('Error sending message:', err);
-      throw err;
-    }
-  }, [connection, chatId, isConnected]);
+      try {
+        // Match backend Message model (PascalCase properties)
+        const payload: { Content: string; SenderId?: string } = { Content: content };
+        if (senderId) {
+          payload.SenderId = senderId;
+        }
+
+        console.log('📡 Sending message via SignalR hub SendMessage:', {
+          chatId,
+          payload,
+        });
+
+        // Invoke hub method; it will save + broadcast
+        const result: any = await connection.invoke('SendMessage', chatId, payload);
+        console.log('✅ Hub SendMessage result:', result);
+        return result;
+      } catch (err) {
+        console.error('Error sending message via SignalR:', err);
+        throw err;
+      }
+    },
+    [connection, chatId, isConnected]
+  );
 
   const addMessage = useCallback((message: ChatMessage) => {
     setMessages((prev) => {

--- a/src/hooks/useSignalR.ts
+++ b/src/hooks/useSignalR.ts
@@ -1,0 +1,226 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { HubConnection, HubConnectionState } from '@microsoft/signalr';
+import { startSignalRConnection, stopSignalRConnection, getSignalRConnection } from '@/lib/signalr/signalr';
+import { ChatMessage } from '@/types/chat/chat.models';
+
+export const useSignalR = (chatId: string | null) => {
+  const [connection, setConnection] = useState<HubConnection | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const chatIdRef = useRef<string | null>(chatId);
+
+  // Keep chatId ref updated
+  useEffect(() => {
+    chatIdRef.current = chatId;
+  }, [chatId]);
+
+  // Initialize SignalR connection
+  useEffect(() => {
+    let isMounted = true;
+    let currentConnection: HubConnection | null = null;
+
+    const initConnection = async () => {
+      try {
+        const conn = await startSignalRConnection();
+        currentConnection = conn;
+        
+        if (isMounted) {
+          setConnection(conn);
+          setIsConnected(conn.state === HubConnectionState.Connected);
+          console.log('🔗 SignalR connection state:', conn.state);
+
+          // Helper to ensure content is always a string
+          const ensureStringContent = (content: any): string => {
+            if (typeof content === 'string') return content;
+            if (content === null || content === undefined) return '';
+            if (typeof content === 'object') {
+              if (content.text) return String(content.text);
+              if (content.message) return String(content.message);
+              return JSON.stringify(content);
+            }
+            return String(content);
+          };
+
+          // Log all SignalR events for debugging
+          console.log('🔍 Setting up SignalR event listeners...');
+          
+          // Listen for ANY method call from SignalR (for debugging)
+          const originalInvoke = conn.invoke.bind(conn);
+          conn.invoke = function(method: string, ...args: any[]) {
+            console.log('📡 SignalR Invoke:', method, args);
+            return originalInvoke(method, ...args);
+          };
+          
+          // Set up message handler - use ref to get current chatId
+          conn.on('ReceiveMessage', (message: any) => {
+            const currentChatId = chatIdRef.current;
+            console.log('📨 Received message via SignalR:', {
+              message,
+              messageChatId: message.chatId || message.chat?.id,
+              currentChatId,
+              messageContent: message.content,
+              messageId: message.id
+            });
+            
+            // Accept message if:
+            // 1. No chatId filter (show all messages), OR
+            // 2. Message matches current chatId
+            const messageChatId = message.chatId || message.chat?.id;
+            const shouldAccept = !currentChatId || messageChatId === currentChatId;
+            
+            if (isMounted && shouldAccept) {
+              // Transform message to match our format
+              const transformedMessage: ChatMessage = {
+                id: String(message.id || `msg-${Date.now()}`),
+                content: ensureStringContent(message.content),
+                senderId: String(message.senderId || message.sender?.id || ''),
+                chatId: String(messageChatId || currentChatId || ''),
+                sentAt: message.sentAt || message.createdAt || message.timestamp,
+                timestamp: message.sentAt || message.createdAt || message.timestamp,
+                status: message.status,
+                sender: message.sender,
+                chat: message.chat,
+              };
+              
+              console.log('✅ Adding message to state:', transformedMessage);
+              setMessages((prev) => {
+                // Avoid duplicates
+                if (prev.some((m) => m.id === transformedMessage.id)) {
+                  console.log('⚠️ Duplicate message ignored:', transformedMessage.id);
+                  return prev;
+                }
+                console.log(`📝 Message added. Total messages: ${prev.length + 1}`);
+                return [...prev, transformedMessage];
+              });
+            } else {
+              console.log('⚠️ Message filtered out:', {
+                reason: !isMounted ? 'Component unmounted' : 'Wrong chatId',
+                messageChatId,
+                currentChatId
+              });
+            }
+          });
+          
+          console.log('👂 SignalR message handler registered. Listening for "ReceiveMessage" events.');
+          
+          // Add a test listener to catch ANY SignalR messages (for debugging)
+          conn.onclose((error) => {
+            if (error) {
+              console.log('🔴 SignalR connection closed with error:', error);
+            }
+          });
+          
+          // Log when ANY method is called on the connection
+          console.log('🔍 Monitoring all SignalR events. If you see messages from backend, they will appear above.');
+
+          // Handle connection state changes
+          conn.onreconnecting(() => {
+            console.log('🔄 SignalR reconnecting...');
+            if (isMounted) setIsConnected(false);
+          });
+
+          conn.onreconnected(() => {
+            console.log('✅ SignalR reconnected');
+            if (isMounted) setIsConnected(true);
+          });
+
+          conn.onclose(() => {
+            console.log('❌ SignalR connection closed');
+            if (isMounted) {
+              setIsConnected(false);
+              setConnection(null);
+            }
+          });
+        }
+      } catch (err) {
+        console.error('Failed to initialize SignalR:', err);
+        console.warn('SignalR connection failed. Real-time messaging will not work, but you can still send/receive messages via API.');
+        if (isMounted) {
+          setIsConnected(false);
+        }
+        // Don't throw - allow app to continue without SignalR
+      }
+    };
+
+    initConnection();
+
+    return () => {
+      isMounted = false;
+      if (currentConnection) {
+        // Remove handlers before stopping
+        currentConnection.off('ReceiveMessage');
+        currentConnection.off('reconnecting');
+        currentConnection.off('reconnected');
+        currentConnection.off('close');
+        stopSignalRConnection();
+      }
+    };
+  }, []); // Only run once on mount
+
+  // Join chat room when chatId changes
+  useEffect(() => {
+    if (!connection || !chatId) return;
+    
+    // Wait a bit for connection to be fully ready
+    const joinChat = async () => {
+      // Check connection state directly
+      if (connection.state !== HubConnectionState.Connected) {
+        console.log(`⏳ Waiting for connection... Current state: ${connection.state}`);
+        return;
+      }
+
+      try {
+        console.log(`🔌 Joining chat room: ${chatId}`);
+        await connection.invoke('JoinChat', chatId);
+        console.log(`✅ Successfully joined chat: ${chatId}`);
+        console.log(`📡 Now listening for real-time messages in chat: ${chatId}`);
+      } catch (err) {
+        console.error('❌ Error joining chat:', err);
+      }
+    };
+
+    // Small delay to ensure connection is ready
+    const timeoutId = setTimeout(joinChat, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+      if (connection && chatId && connection.state === HubConnectionState.Connected) {
+        console.log(`🔌 Leaving chat room: ${chatId}`);
+        connection.invoke('LeaveChat', chatId).catch((err) => {
+          console.error('❌ Error leaving chat:', err);
+        });
+      }
+    };
+  }, [connection, chatId, isConnected]);
+
+  const sendMessage = useCallback(async (content: string) => {
+    if (!connection || !chatId || !isConnected) {
+      throw new Error('Not connected to chat');
+    }
+
+    try {
+      await connection.invoke('SendMessage', chatId, content);
+    } catch (err) {
+      console.error('Error sending message:', err);
+      throw err;
+    }
+  }, [connection, chatId, isConnected]);
+
+  const addMessage = useCallback((message: ChatMessage) => {
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === message.id)) {
+        return prev;
+      }
+      return [...prev, message];
+    });
+  }, []);
+
+  return {
+    connection,
+    isConnected,
+    messages,
+    setMessages,
+    sendMessage,
+    addMessage,
+  };
+};

--- a/src/lib/api/message.ts
+++ b/src/lib/api/message.ts
@@ -1,0 +1,105 @@
+import { getSavedToken } from '@/utils/authToken';
+import api from './client';
+import { ChatMessage, SendMessageRequest } from '@/types/chat/chat.models';
+
+export async function sendMessage(chatId: string, content: string, senderId?: string): Promise<ChatMessage> {
+  const token = getSavedToken();
+  if (!token) throw new Error('No auth token found');
+
+  try {
+    // Build request body - backend requires Content and SenderId (PascalCase)
+    const requestBody: { Content: string; SenderId?: string } = { Content: content };
+    if (senderId) {
+      requestBody.SenderId = senderId;
+    }
+    
+    console.log('🌐 API Request: POST /chat/' + chatId + '/message', requestBody);
+    const response = await api.post(
+      `/chat/${chatId}/message`,
+      requestBody,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    
+    console.log('📥 API Response received:', response.data);
+    
+    // Handle API response structure
+    const data = response.data;
+    
+    // If response has isSuccess wrapper
+    if (data?.isSuccess && data?.data) {
+      console.log('✅ Message sent successfully. Response:', data.data);
+      return data.data;
+    }
+    
+    // If response.data exists
+    if (data?.data) {
+      console.log('✅ Message sent successfully. Response:', data.data);
+      return data.data;
+    }
+    
+    // Direct response
+    console.log('✅ Message sent successfully. Response:', data);
+    return data;
+  } catch (err: any) {
+    console.error('❌ API Error sending message:', err);
+    if (err.response) {
+      console.error('Response status:', err.response.status);
+      console.error('Response data:', err.response.data);
+      if (err.response.data) {
+        throw err.response.data;
+      }
+    }
+    throw err;
+  }
+}
+
+export async function getMessages(chatId: string): Promise<ChatMessage[]> {
+  const token = getSavedToken();
+  if (!token) throw new Error('No auth token found');
+
+  try {
+    const response = await api.get(
+      `/chat/${chatId}/message`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    
+    // Handle API response structure
+    const data = response.data;
+    
+    // If response has isSuccess wrapper
+    if (data?.isSuccess && data?.data && Array.isArray(data.data)) {
+      return data.data;
+    }
+    
+    // If response.data is an array
+    if (data?.data && Array.isArray(data.data)) {
+      return data.data;
+    }
+    
+    // If data is directly an array
+    if (Array.isArray(data)) {
+      return data;
+    }
+    
+    console.warn('Unexpected message response structure:', data);
+    return [];
+  } catch (err: any) {
+    console.error('Error fetching messages:', err);
+    if (err.response) {
+      console.error('Response status:', err.response.status);
+      console.error('Response data:', err.response.data);
+      if (err.response.data) {
+        throw err.response.data;
+      }
+    }
+    throw err;
+  }
+}

--- a/src/lib/signalr/signalr.ts
+++ b/src/lib/signalr/signalr.ts
@@ -1,0 +1,125 @@
+import * as signalR from '@microsoft/signalr';
+import { getSavedToken } from '@/utils/authToken';
+
+let connection: signalR.HubConnection | null = null;
+let connectionPromise: Promise<signalR.HubConnection> | null = null;
+
+export const getSignalRConnection = (): signalR.HubConnection | null => {
+  if (connection && connection.state === signalR.HubConnectionState.Connected) {
+    return connection;
+  }
+  return null;
+};
+
+export const startSignalRConnection = async (): Promise<signalR.HubConnection> => {
+  const token = getSavedToken();
+  if (!token) {
+    throw new Error('No auth token found');
+  }
+
+  // If already connected, return existing connection
+  if (connection && connection.state === signalR.HubConnectionState.Connected) {
+    return connection;
+  }
+
+  // If connection is in progress, wait for it
+  if (connectionPromise) {
+    return connectionPromise;
+  }
+
+  // Close existing connection if any (but not connected)
+  if (connection) {
+    await stopSignalRConnection();
+  }
+
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+  
+  // Construct the SignalR hub URL
+  // The hub is at /hubs/chat (the /negotiate endpoint is added automatically by SignalR)
+  // You can set NEXT_PUBLIC_SIGNALR_HUB_URL in .env to override
+  
+  let hubUrl: string;
+  if (process.env.NEXT_PUBLIC_SIGNALR_HUB_URL) {
+    // Use explicit hub URL from env
+    hubUrl = process.env.NEXT_PUBLIC_SIGNALR_HUB_URL;
+  } else {
+    // Remove /api from base URL and add /hubs/chat
+    const baseUrl = apiBaseUrl.replace(/\/api\/?$/, ''); // Remove trailing /api
+    hubUrl = `${baseUrl}/hubs/chat`;
+  }
+  
+  console.log('Attempting to connect to SignalR hub at:', hubUrl);
+
+  // Create connection promise to prevent multiple simultaneous connections
+  connectionPromise = (async () => {
+    const newConnection = new signalR.HubConnectionBuilder()
+      .withUrl(hubUrl, {
+        accessTokenFactory: () => {
+          // Return the token - SignalR will send it as query parameter (access_token)
+          // This is the standard way SignalR handles authentication
+          return token;
+        },
+      })
+      .withAutomaticReconnect({
+        nextRetryDelayInMilliseconds: (retryContext) => {
+          // Exponential backoff: 0s, 2s, 10s, 30s, then 30s intervals
+          if (retryContext.previousRetryCount === 0) return 0;
+          if (retryContext.previousRetryCount === 1) return 2000;
+          if (retryContext.previousRetryCount === 2) return 10000;
+          return 30000;
+        }
+      })
+      .build();
+
+    try {
+      await newConnection.start();
+      console.log('✅ SignalR Connected successfully to:', hubUrl);
+      connection = newConnection;
+      connectionPromise = null; // Clear promise on success
+      return connection;
+    } catch (err: any) {
+      console.error('❌ SignalR Connection Error:', err);
+      console.error('Hub URL attempted:', hubUrl);
+      console.error('Make sure:');
+      console.error('1. The SignalR hub is configured in your .NET backend');
+      console.error('2. The hub URL path is correct (common: /api/chathub, /chathub, /hub/chat)');
+      console.error('3. CORS is properly configured for SignalR');
+      console.error('4. Set NEXT_PUBLIC_SIGNALR_HUB_URL in .env if using a different path');
+      connection = null;
+      connectionPromise = null; // Clear promise on error
+      throw err;
+    }
+  })();
+
+  return connectionPromise;
+};
+
+export const stopSignalRConnection = async (): Promise<void> => {
+  // Clear any pending connection promise
+  connectionPromise = null;
+  
+  if (connection) {
+    try {
+      await connection.stop();
+      console.log('SignalR Disconnected');
+    } catch (err) {
+      console.error('Error stopping SignalR connection:', err);
+    } finally {
+      connection = null;
+    }
+  }
+};
+
+export const sendMessageViaSignalR = async (chatId: string, content: string): Promise<void> => {
+  const conn = getSignalRConnection();
+  if (!conn) {
+    throw new Error('SignalR connection not established');
+  }
+  
+  try {
+    await conn.invoke('SendMessage', chatId, content);
+  } catch (err) {
+    console.error('Error sending message via SignalR:', err);
+    throw err;
+  }
+};

--- a/src/lib/signalr/signalr.ts
+++ b/src/lib/signalr/signalr.ts
@@ -1,9 +1,12 @@
-import * as signalR from '@microsoft/signalr';
-import { getSavedToken } from '@/utils/authToken';
+import * as signalR from "@microsoft/signalr";
+import { getSavedToken } from "@/utils/authToken";
 
 let connection: signalR.HubConnection | null = null;
 let connectionPromise: Promise<signalR.HubConnection> | null = null;
 
+/**
+ * Get the active SignalR connection if connected
+ */
 export const getSignalRConnection = (): signalR.HubConnection | null => {
   if (connection && connection.state === signalR.HubConnectionState.Connected) {
     return connection;
@@ -11,115 +14,117 @@ export const getSignalRConnection = (): signalR.HubConnection | null => {
   return null;
 };
 
+/**
+ * Start SignalR connection (singleton + race-safe)
+ */
 export const startSignalRConnection = async (): Promise<signalR.HubConnection> => {
   const token = getSavedToken();
   if (!token) {
-    throw new Error('No auth token found');
+    throw new Error("No auth token found");
   }
 
-  // If already connected, return existing connection
+  // ✅ Already connected → reuse connection
   if (connection && connection.state === signalR.HubConnectionState.Connected) {
     return connection;
   }
 
-  // If connection is in progress, wait for it
+  // ✅ Connection is already being created → wait for it
   if (connectionPromise) {
     return connectionPromise;
   }
 
-  // Close existing connection if any (but not connected)
+  // ✅ Stop old connection if exists but not connected
   if (connection) {
     await stopSignalRConnection();
   }
 
-  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || '';
-  
-  // Construct the SignalR hub URL
-  // The hub is at /hubs/chat (the /negotiate endpoint is added automatically by SignalR)
-  // You can set NEXT_PUBLIC_SIGNALR_HUB_URL in .env to override
-  
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+
+  // Build hub URL
   let hubUrl: string;
   if (process.env.NEXT_PUBLIC_SIGNALR_HUB_URL) {
-    // Use explicit hub URL from env
     hubUrl = process.env.NEXT_PUBLIC_SIGNALR_HUB_URL;
   } else {
-    // Remove /api from base URL and add /hubs/chat
-    const baseUrl = apiBaseUrl.replace(/\/api\/?$/, ''); // Remove trailing /api
+    const baseUrl = apiBaseUrl.replace(/\/api\/?$/, "");
     hubUrl = `${baseUrl}/hubs/chat`;
   }
-  
-  console.log('Attempting to connect to SignalR hub at:', hubUrl);
 
-  // Create connection promise to prevent multiple simultaneous connections
-  connectionPromise = (async () => {
+  console.log("Attempting to connect to SignalR hub at:", hubUrl);
+
+  // ✅ Assign promise immediately (prevents race condition)
+  connectionPromise = new Promise<signalR.HubConnection>((resolve, reject) => {
     const newConnection = new signalR.HubConnectionBuilder()
       .withUrl(hubUrl, {
-        accessTokenFactory: () => {
-          // Return the token - SignalR will send it as query parameter (access_token)
-          // This is the standard way SignalR handles authentication
-          return token;
-        },
+        accessTokenFactory: () => token,
       })
       .withAutomaticReconnect({
         nextRetryDelayInMilliseconds: (retryContext) => {
-          // Exponential backoff: 0s, 2s, 10s, 30s, then 30s intervals
           if (retryContext.previousRetryCount === 0) return 0;
           if (retryContext.previousRetryCount === 1) return 2000;
           if (retryContext.previousRetryCount === 2) return 10000;
           return 30000;
-        }
+        },
       })
       .build();
 
-    try {
-      await newConnection.start();
-      console.log('✅ SignalR Connected successfully to:', hubUrl);
-      connection = newConnection;
-      connectionPromise = null; // Clear promise on success
-      return connection;
-    } catch (err: any) {
-      console.error('❌ SignalR Connection Error:', err);
-      console.error('Hub URL attempted:', hubUrl);
-      console.error('Make sure:');
-      console.error('1. The SignalR hub is configured in your .NET backend');
-      console.error('2. The hub URL path is correct (common: /api/chathub, /chathub, /hub/chat)');
-      console.error('3. CORS is properly configured for SignalR');
-      console.error('4. Set NEXT_PUBLIC_SIGNALR_HUB_URL in .env if using a different path');
-      connection = null;
-      connectionPromise = null; // Clear promise on error
-      throw err;
-    }
-  })();
+    newConnection
+      .start()
+      .then(() => {
+        console.log("✅ SignalR Connected successfully to:", hubUrl);
+
+        connection = newConnection;
+        connectionPromise = null;
+
+        resolve(newConnection);
+      })
+      .catch((err) => {
+        console.error("❌ SignalR Connection Error:", err);
+
+        connection = null;
+        connectionPromise = null;
+
+        reject(err);
+      });
+  });
 
   return connectionPromise;
 };
 
+/**
+ * Stop SignalR connection safely
+ */
 export const stopSignalRConnection = async (): Promise<void> => {
-  // Clear any pending connection promise
+  // Clear any pending promise
   connectionPromise = null;
-  
+
   if (connection) {
     try {
       await connection.stop();
-      console.log('SignalR Disconnected');
+      console.log("SignalR Disconnected");
     } catch (err) {
-      console.error('Error stopping SignalR connection:', err);
+      console.error("Error stopping SignalR connection:", err);
     } finally {
       connection = null;
     }
   }
 };
 
-export const sendMessageViaSignalR = async (chatId: string, content: string): Promise<void> => {
+/**
+ * Send a message through SignalR hub
+ */
+export const sendMessageViaSignalR = async (
+  chatId: string,
+  content: string
+): Promise<void> => {
   const conn = getSignalRConnection();
   if (!conn) {
-    throw new Error('SignalR connection not established');
+    throw new Error("SignalR connection not established");
   }
-  
+
   try {
-    await conn.invoke('SendMessage', chatId, content);
+    await conn.invoke("SendMessage", chatId, content);
   } catch (err) {
-    console.error('Error sending message via SignalR:', err);
+    console.error("Error sending message via SignalR:", err);
     throw err;
   }
 };

--- a/src/types/chat/chat.models.ts
+++ b/src/types/chat/chat.models.ts
@@ -11,9 +11,29 @@ export interface ChatMessage {
   id: string;
   content: string;
   senderId: string;
-  receiverId: string;
-  timestamp: string;
+  receiverId?: string;
+  chatId?: string;
+  timestamp?: string;
+  sentAt?: string;
+  createdAt?: string;
   isRead?: boolean;
+  status?: 'sent' | 'delivered' | 'seen';
+  // Nested objects from API
+  sender?: {
+    id: string;
+    userName: string;
+    displayName?: string;
+    image?: string;
+  };
+  chat?: {
+    id: string;
+    isGroupChat: boolean;
+    groupName?: string;
+  };
+}
+
+export interface SendMessageRequest {
+  content: string;
 }
 
 export interface UserChat {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new SignalR connection and message flow (optimistic UI + hub broadcasts) plus a global auth redirect, which can impact chat reliability and navigation if event payloads or auth init timing differ from expectations.
> 
> **Overview**
> Adds real-time chat plumbing via SignalR: introduces a singleton connection manager (`lib/signalr/signalr.ts`) and a new `useSignalR` hook that joins/leaves chat groups, listens for `MessageReceived`, dedupes against optimistic temp messages, and invokes hub `SendMessage`.
> 
> Replaces `ChatWindow`’s fake data with API-backed history (`getMessages`) plus optimistic sending + status ticks, and updates `ChatPage` to pass `chatId` (vs `userId`). `ChatSidebar` now normalizes `lastMessage` to a string for safer rendering. Also adds a global `RouteGuard` wrapping providers to redirect unauthenticated users to `/auth/signin`.
> 
> Includes a new `docs/chat-realtime-spec.md` implementation spec and adds `@microsoft/signalr` (and lockfile deps), plus expands `ChatMessage` typing to support chat/message metadata and delivery status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b24754c7666a4d2d5acd42990fc7c9b154651ef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->